### PR TITLE
Renaming connection objects and some cleanup

### DIFF
--- a/linien/client/connection.py
+++ b/linien/client/connection.py
@@ -188,8 +188,6 @@ class LinienClient(RawRPYCClient):
         self.connection = None
 
         i = -1
-        server_was_started = False
-
         while True:
             i += 1
 
@@ -212,19 +210,20 @@ class LinienClient(RawRPYCClient):
             except EOFError:
                 print("EOFError! Probably authentication failed")
                 raise RPYCAuthenticationException()
-            except Exception as e:
+            except Exception:
                 if not self.autostart_server:
                     raise ServerNotRunningException()
 
                 if i == 0:
                     print("server is not running. Launching it!")
-                    server_was_started = True
                     run_server(host, user, password, port)
                     sleep(3)
                 else:
                     if i < 20:
                         print(
-                            "server still not running, waiting (this may take some time)..."
+                            """
+                            Server still not running, waiting (this may take some time).
+                            """
                         )
                         sleep(1)
                     else:

--- a/linien/gui/app.py
+++ b/linien/gui/app.py
@@ -6,7 +6,7 @@ from plumbum import colors
 from traceback import print_exc
 
 from PyQt5 import QtWidgets
-from pyqtgraph.Qt import QtCore, QtGui
+from pyqtgraph.Qt import QtCore
 
 
 # it may seem odd to include '.', but for some reason this is needed for
@@ -62,9 +62,12 @@ class QTApp(QtCore.QObject):
         for instance in CustomWidget.instances:
             try:
                 instance.connection_established()
-            except:
+            except Exception:
                 print(
-                    "the error below happend when calling connection_established of a widget. This may happen if the widget was recently destroyed."
+                    """
+                    The error below happend when calling connection_established of a 
+                    widget. This may happen if the widget was recently destroyed.
+                    """  # noqa: W291
                 )
                 print_exc()
 
@@ -76,7 +79,7 @@ class QTApp(QtCore.QObject):
         if hasattr(self, "client") and self.client and self.client.connected:
             try:
                 self.parameters.call_listeners()
-            except:
+            except Exception:
                 print(colors.red | "call_listeners() failed")
                 print_exc()
 

--- a/linien/gui/app.py
+++ b/linien/gui/app.py
@@ -46,18 +46,19 @@ class QTApp(QtCore.QObject):
 
         super().__init__()
 
-    def connected(self, connection, parameters, control):
+    def client_connected(self, client):
         self.device_manager.hide()
-        self.main_window.show(connection.host, connection.device["name"])
+        self.main_window.show(client.host, client.device["name"])
 
-        self.connection = connection
-        self.control = control
-        self.parameters = parameters
+        self.client = client
+        self.control = client.control
+        self.parameters = client.parameters
 
         self.ready.connect(self.init)
         self.ready.emit(True)
 
     def init(self):
+
         for instance in CustomWidget.instances:
             try:
                 instance.connection_established()
@@ -72,11 +73,7 @@ class QTApp(QtCore.QObject):
         self.check_for_new_version()
 
     def call_listeners(self):
-        if (
-            hasattr(self, "connection")
-            and self.connection
-            and self.connection.connected
-        ):
+        if hasattr(self, "client") and self.client and self.client.connected:
             try:
                 self.parameters.call_listeners()
             except:
@@ -94,7 +91,7 @@ class QTApp(QtCore.QObject):
         self.app.quit()
 
     def shutdown(self):
-        self.control.shutdown()
+        self.client.control.shutdown()
         self.close()
 
     def open_psd_window(self):
@@ -107,8 +104,8 @@ class QTApp(QtCore.QObject):
         self.main_window.hide()
         self.device_manager.show()
 
-        self.connection.disconnect()
-        del self.connection
+        self.client.disconnect()
+        del self.client
 
     def close_all_secondary_windows(self):
         self.psd_window.hide()

--- a/linien/gui/ui/device_manager.py
+++ b/linien/gui/ui/device_manager.py
@@ -87,7 +87,10 @@ class DeviceManager(QtGui.QMainWindow, CustomWidget):
             client_version = linien.__version__
             loading_dialog.hide()
             if not aborted:
-                display_question = """The server is not yet installed on the device. Should it be installed? (Requires internet connection on RedPitaya)"""
+                display_question = """
+                The server is not yet installed on the device. 
+                Should it be installed? (Requires internet connection on RedPitaya)
+                """  # noqa: W291
                 if question_dialog(self, display_question, "Install server?"):
                     self.install_linien_server(
                         device,
@@ -100,24 +103,25 @@ class DeviceManager(QtGui.QMainWindow, CustomWidget):
             loading_dialog.hide()
             if not aborted:
                 if client_version != "dev":
-                    display_question = (
-                        "The server version (%s) does not match the client (%s) version."
-                        "Should the corresponding server version be installed?"
-                        % (remote_version, client_version)
+                    display_question = """
+                        The server version ({}) does not match the client ({})
+                        version. Should the corresponding server version be installed?
+                        """.format(
+                        remote_version, client_version
                     )
                     if question_dialog(
                         self, display_question, "Install corresponding version?"
                     ):
                         self.install_linien_server(device, version=client_version)
                 else:
-                    display_error = (
-                        "A production version is installed on the RedPitaya, "
-                        "but the client uses a development version. Stop the "
-                        "server and uninstall the version on the RedPitaya using\n"
-                        "    linien_stop_server;\n"
-                        "    pip3 uninstall linien-server\n"
-                        "before trying it again."
-                    )
+                    display_error = """
+                        A production version is installed on the RedPitaya, 
+                        but the client uses a development version. Stop the 
+                        server and uninstall the version on the RedPitaya using\n
+                        linien_stop_server;\n
+                        pip3 uninstall linien-server\n
+                        before trying it again.
+                        """  # noqa: W291
                     error_dialog(self, display_error)
 
         self.t.invalid_server_version.connect(invalid_server_version)
@@ -125,11 +129,12 @@ class DeviceManager(QtGui.QMainWindow, CustomWidget):
         def authentication_exception():
             loading_dialog.hide()
             if not aborted:
-                display_error = (
-                    "Error at authentication. "
-                    'Check username and password (by default both are "root") and verify that you '
-                    "don't have any offending SSH keys in your known hosts file."
-                )
+                display_error = """
+                    Error at authentication.\n
+                    Check username and password (by default both are "root") and verify 
+                    that you don't have any offending SSH keys in your known hosts file.
+                    """  # noqa: W291
+
                 error_dialog(self, display_error)
 
         self.t.authentication_exception.connect(authentication_exception)
@@ -137,7 +142,10 @@ class DeviceManager(QtGui.QMainWindow, CustomWidget):
         def general_connection_error():
             loading_dialog.hide()
             if not aborted:
-                display_error = "Unable to connect to device. If you are connecting by hostname (i.e. rp-xxxxxx.local), try using IP address instead."
+                display_error = """
+                Unable to connect to device. If you are connecting by hostname 
+                (i.e. rp-xxxxxx.local), try using IP address instead.
+                """  # noqa: W291
                 error_dialog(self, display_error)
 
         self.t.general_connection_error.connect(general_connection_error)
@@ -151,7 +159,13 @@ class DeviceManager(QtGui.QMainWindow, CustomWidget):
         self.t.exception.connect(exception)
 
         def ask_for_parameter_restore():
-            question = "Linien on RedPitaya is running with different parameters than the ones saved locally on this machine. Do you want to upload the local parameters or keep the remote ones? Note that remote parameters are only saved if Linien server was shut down properly, not when unplugging the power plug. In this case, you should update your local parameters."
+            question = """
+            Linien on RedPitaya is running with different parameters than the ones saved
+             locally on this machine. Do you want to upload the local parameters or keep
+             the remote ones? Note that remote parameters are only saved if Linien 
+            server was shut down properly, not when unplugging the power plug. In this 
+            case, you should update your local parameters.
+            """  # noqa: W291
             should_restore = ask_for_parameter_restore_dialog(
                 self, question, "Restore parameters?"
             )

--- a/linien/gui/ui/general_panel.py
+++ b/linien/gui/ui/general_panel.py
@@ -58,9 +58,8 @@ class GeneralPanel(QtGui.QWidget, CustomWidget):
         self.control.write_data()
 
     def connection_established(self):
-        params = self.app.parameters
+        self.parameters = self.app.parameters
         self.control = self.app.control
-        self.parameters = params
 
         def dual_channel_changed(value):
             self.ids.dual_channel_mixing.setVisible(value)
@@ -72,34 +71,36 @@ class GeneralPanel(QtGui.QWidget, CustomWidget):
             )
             return value
 
-        param2ui(params.dual_channel, self.ids.dual_channel, dual_channel_changed)
+        param2ui(
+            self.parameters.dual_channel, self.ids.dual_channel, dual_channel_changed
+        )
 
         param2ui(
-            params.channel_mixing,
+            self.parameters.channel_mixing,
             self.ids.channel_mixing_slider,
             lambda value: value + 128,
         )
         # this is required to update the descriptive labels in the beginning
         self.channel_mixing_changed()
 
-        param2ui(params.mod_channel, self.ids.mod_channel)
-        param2ui(params.control_channel, self.ids.control_channel)
-        param2ui(params.sweep_channel, self.ids.sweep_channel)
-        param2ui(params.pid_on_slow_enabled, self.ids.slow_control_channel)
+        param2ui(self.parameters.mod_channel, self.ids.mod_channel)
+        param2ui(self.parameters.control_channel, self.ids.control_channel)
+        param2ui(self.parameters.sweep_channel, self.ids.sweep_channel)
+        param2ui(self.parameters.pid_on_slow_enabled, self.ids.slow_control_channel)
 
-        param2ui(params.polarity_fast_out1, self.ids.polarity_fast_out1)
-        param2ui(params.polarity_fast_out2, self.ids.polarity_fast_out2)
-        param2ui(params.polarity_analog_out0, self.ids.polarity_analog_out0)
+        param2ui(self.parameters.polarity_fast_out1, self.ids.polarity_fast_out1)
+        param2ui(self.parameters.polarity_fast_out2, self.ids.polarity_fast_out2)
+        param2ui(self.parameters.polarity_analog_out0, self.ids.polarity_analog_out0)
 
         def show_polarity_settings(*args):
             used_channels = set(
                 (
-                    params.control_channel.value,
-                    params.sweep_channel.value,
+                    self.parameters.control_channel.value,
+                    self.parameters.sweep_channel.value,
                 )
             )
 
-            if params.pid_on_slow_enabled.value:
+            if self.parameters.pid_on_slow_enabled.value:
                 used_channels.add(ANALOG_OUT0)
 
             self.ids.polarity_selector.setVisible(len(used_channels) > 1)
@@ -111,17 +112,17 @@ class GeneralPanel(QtGui.QWidget, CustomWidget):
             set_visibility(self.ids.polarity_container_fast_out2, FAST_OUT2)
             set_visibility(self.ids.polarity_container_analog_out0, ANALOG_OUT0)
 
-        params.control_channel.on_change(show_polarity_settings)
-        params.sweep_channel.on_change(show_polarity_settings)
-        params.mod_channel.on_change(show_polarity_settings)
-        params.pid_on_slow_enabled.on_change(show_polarity_settings)
+        self.parameters.control_channel.on_change(show_polarity_settings)
+        self.parameters.sweep_channel.on_change(show_polarity_settings)
+        self.parameters.mod_channel.on_change(show_polarity_settings)
+        self.parameters.pid_on_slow_enabled.on_change(show_polarity_settings)
 
         for idx in range(4):
             if idx == 0:
                 continue
             name = "analog_out_%d" % idx
             param2ui(
-                getattr(params, name),
+                getattr(self.parameters, name),
                 getattr(self.ids, name),
                 process_value=lambda v: ANALOG_OUT_V * v,
             )

--- a/linien/gui/ui/general_panel.py
+++ b/linien/gui/ui/general_panel.py
@@ -58,8 +58,8 @@ class GeneralPanel(QtGui.QWidget, CustomWidget):
         self.control.write_data()
 
     def connection_established(self):
-        params = self.app().parameters
-        self.control = self.app().control
+        params = self.app.parameters
+        self.control = self.app.control
         self.parameters = params
 
         def dual_channel_changed(value):

--- a/linien/gui/ui/lock_status_panel.py
+++ b/linien/gui/ui/lock_status_panel.py
@@ -16,8 +16,8 @@ class LockStatusPanel(QtGui.QWidget, CustomWidget):
         )
 
     def connection_established(self):
-        self.control = self.app().control
-        params = self.app().parameters
+        self.control = self.app.control
+        params = self.app.parameters
         self.parameters = params
 
         def update_status(_):

--- a/linien/gui/ui/lock_status_panel.py
+++ b/linien/gui/ui/lock_status_panel.py
@@ -16,18 +16,17 @@ class LockStatusPanel(QtGui.QWidget, CustomWidget):
         )
 
     def connection_established(self):
+        self.parameters = self.app.parameters
         self.control = self.app.control
-        params = self.app.parameters
-        self.parameters = params
 
         def update_status(_):
-            locked = params.lock.value
-            task = params.task.value
-            al_failed = params.autolock_failed.value
-            running = params.autolock_running.value
-            retrying = params.autolock_retrying.value
-            percentage = params.autolock_percentage.value
-            preparing = params.autolock_preparing.value
+            locked = self.parameters.lock.value
+            task = self.parameters.task.value
+            al_failed = self.parameters.autolock_failed.value
+            running = self.parameters.autolock_running.value
+            retrying = self.parameters.autolock_retrying.value
+            percentage = self.parameters.autolock_percentage.value
+            preparing = self.parameters.autolock_preparing.value
 
             if locked or (task is not None and not al_failed):
                 self.show()
@@ -35,7 +34,7 @@ class LockStatusPanel(QtGui.QWidget, CustomWidget):
                 self.hide()
 
             if task:
-                watching = params.autolock_watching.value
+                watching = self.parameters.autolock_watching.value
             else:
                 running = False
                 watching = False
@@ -56,20 +55,21 @@ class LockStatusPanel(QtGui.QWidget, CustomWidget):
                     set_text("Trying again to lock...")
 
         for param in (
-            params.lock,
-            params.task,
-            params.autolock_running,
-            params.autolock_preparing,
-            params.autolock_watching,
-            params.autolock_failed,
-            params.autolock_locked,
-            params.autolock_retrying,
-            params.autolock_percentage,
+            self.parameters.lock,
+            self.parameters.task,
+            self.parameters.autolock_running,
+            self.parameters.autolock_preparing,
+            self.parameters.autolock_watching,
+            self.parameters.autolock_failed,
+            self.parameters.autolock_locked,
+            self.parameters.autolock_retrying,
+            self.parameters.autolock_percentage,
         ):
             param.on_change(update_status)
 
         param2ui(
-            params.control_signal_history_length, self.ids.control_signal_history_length
+            self.parameters.control_signal_history_length,
+            self.ids.control_signal_history_length,
         )
 
     def stop_lock(self):

--- a/linien/gui/ui/locking_panel.py
+++ b/linien/gui/ui/locking_panel.py
@@ -42,9 +42,9 @@ class LockingPanel(QtGui.QWidget, CustomWidget):
         )
 
     def connection_established(self):
-        params = self.app().parameters
+        params = self.app.parameters
         self.parameters = params
-        self.control = self.app().control
+        self.control = self.app.control
 
         param2ui(params.p, self.ids.kp)
         param2ui(params.i, self.ids.ki)

--- a/linien/gui/ui/locking_panel.py
+++ b/linien/gui/ui/locking_panel.py
@@ -42,13 +42,12 @@ class LockingPanel(QtGui.QWidget, CustomWidget):
         )
 
     def connection_established(self):
-        params = self.app.parameters
-        self.parameters = params
+        self.parameters = self.app.parameters
         self.control = self.app.control
 
-        param2ui(params.p, self.ids.kp)
-        param2ui(params.i, self.ids.ki)
-        param2ui(params.d, self.ids.kd)
+        param2ui(self.parameters.p, self.ids.kp)
+        param2ui(self.parameters.i, self.ids.ki)
+        param2ui(self.parameters.d, self.ids.kd)
 
         # param2ui(params.check_lock, self.ids.checkLockCheckbox)
         # param2ui(params.watch_lock, self.ids.watchLockCheckbox)
@@ -57,25 +56,25 @@ class LockingPanel(QtGui.QWidget, CustomWidget):
         #    self.ids.watch_lock_threshold,
         #    lambda v: v * 100,
         # )
-        param2ui(params.autolock_determine_offset, self.ids.autoOffsetCheckbox)
+        param2ui(self.parameters.autolock_determine_offset, self.ids.autoOffsetCheckbox)
         param2ui(
-            params.automatic_mode,
+            self.parameters.automatic_mode,
             self.ids.lock_control_container,
             lambda value: 0 if value else 1,
         )
-        param2ui(params.pid_on_slow_strength, self.ids.pid_on_slow_strength)
+        param2ui(self.parameters.pid_on_slow_strength, self.ids.pid_on_slow_strength)
 
         def slow_pid_visibility(*args):
             self.ids.slow_pid_group.setVisible(
                 self.parameters.pid_on_slow_enabled.value
             )
 
-        params.pid_on_slow_enabled.on_change(slow_pid_visibility)
+        self.parameters.pid_on_slow_enabled.on_change(slow_pid_visibility)
 
         def lock_status_changed(_):
-            locked = params.lock.value
-            task = params.task.value
-            al_failed = params.autolock_failed.value
+            locked = self.parameters.lock.value
+            task = self.parameters.task.value
+            al_failed = self.parameters.autolock_failed.value
             task_running = (task is not None) and (not al_failed)
 
             if locked or task_running or al_failed:
@@ -86,17 +85,17 @@ class LockingPanel(QtGui.QWidget, CustomWidget):
             self.ids.lock_failed.setVisible(al_failed)
 
         for param in (
-            params.lock,
-            params.autolock_preparing,
-            params.autolock_watching,
-            params.autolock_failed,
-            params.autolock_locked,
+            self.parameters.lock,
+            self.parameters.autolock_preparing,
+            self.parameters.autolock_watching,
+            self.parameters.autolock_failed,
+            self.parameters.autolock_locked,
         ):
             param.on_change(lock_status_changed)
 
-        param2ui(params.target_slope_rising, self.ids.button_slope_rising)
+        param2ui(self.parameters.target_slope_rising, self.ids.button_slope_rising)
         param2ui(
-            params.target_slope_rising,
+            self.parameters.target_slope_rising,
             self.ids.button_slope_falling,
             lambda value: not value,
         )
@@ -105,9 +104,11 @@ class LockingPanel(QtGui.QWidget, CustomWidget):
             self.ids.auto_mode_activated.setVisible(value)
             self.ids.auto_mode_not_activated.setVisible(not value)
 
-        params.autolock_selection.on_change(autolock_selection_status_changed)
+        self.parameters.autolock_selection.on_change(autolock_selection_status_changed)
 
-        param2ui(params.autolock_mode_preference, self.ids.autolock_mode_preference)
+        param2ui(
+            self.parameters.autolock_mode_preference, self.ids.autolock_mode_preference
+        )
 
     def kp_changed(self):
         self.parameters.p.value = self.ids.kp.value()

--- a/linien/gui/ui/main_window.py
+++ b/linien/gui/ui/main_window.py
@@ -129,8 +129,8 @@ class MainWindow(QtGui.QMainWindow, CustomWidget):
             self.control.write_data()
 
     def connection_established(self):
-        self.control = self.app.control
         self.parameters = self.app.parameters
+        self.control = self.app.control
         # FIXME: ramp slider should use the values from `self.parameters`
         self.ids.ramp_slider.initValues()
 

--- a/linien/gui/ui/main_window.py
+++ b/linien/gui/ui/main_window.py
@@ -34,8 +34,6 @@ class MainWindow(QtGui.QMainWindow, CustomWidget):
         # handle keyboard events
         self.setFocus()
 
-        # FIXME: Ramp slider should be disabled until connection is established and we
-        # actually know what value range is actually set.
         self.ids.ramp_slider.valueChanged.connect(self.change_ramp)
 
         self.ids.export_parameters_button.clicked.connect(
@@ -129,16 +127,20 @@ class MainWindow(QtGui.QMainWindow, CustomWidget):
             self.control.write_data()
 
     def connection_established(self):
-        self.parameters = self.app.parameters
         self.control = self.app.control
-        # FIXME: ramp slider should use the values from `self.parameters`
-        self.ids.ramp_slider.initValues()
+        self.parameters = self.app.parameters
+
+        # initialize ramp controls
+        self.ids.ramp_slider.init()
+        amplitude = self.parameters.ramp_amplitude.value
+        center = self.parameters.center.value
+        self.ids.ramp_slider.setValue((center - amplitude, center + amplitude))
 
         def display_ramp_range(*args):
             center = self.parameters.center.value
-            amp = self.parameters.ramp_amplitude.value
-            min_ = center - amp
-            max_ = center + amp
+            amplitude = self.parameters.ramp_amplitude.value
+            min_ = center - amplitude
+            max_ = center + amplitude
             self.ids.ramp_status.setText("{:+.3f}V to {:+.3f}V".format(min_, max_))
 
         self.parameters.center.on_change(display_ramp_range)

--- a/linien/gui/ui/main_window.py
+++ b/linien/gui/ui/main_window.py
@@ -129,8 +129,9 @@ class MainWindow(QtGui.QMainWindow, CustomWidget):
             self.control.write_data()
 
     def connection_established(self):
+        print("jo")
         self.control = self.app.control
-        self.parameters = self.app.parameters
+        self.parameters = self.app.client.parameters
         # FIXME: ramp slider should use the values from `self.parameters`
         self.ids.ramp_slider.initValues()
 

--- a/linien/gui/ui/main_window.py
+++ b/linien/gui/ui/main_window.py
@@ -129,9 +129,8 @@ class MainWindow(QtGui.QMainWindow, CustomWidget):
             self.control.write_data()
 
     def connection_established(self):
-        print("jo")
         self.control = self.app.control
-        self.parameters = self.app.client.parameters
+        self.parameters = self.app.parameters
         # FIXME: ramp slider should use the values from `self.parameters`
         self.ids.ramp_slider.initValues()
 

--- a/linien/gui/ui/modulation_ramp_panel.py
+++ b/linien/gui/ui/modulation_ramp_panel.py
@@ -24,23 +24,22 @@ class ModulationAndRampPanel(QtGui.QWidget, CustomWidget):
         self.ids.spectroscopyTabs.setCurrentIndex(0)
 
     def connection_established(self):
-        params = self.app.parameters
+        self.parameters = self.app.parameters
         self.control = self.app.control
-        self.parameters = params
 
         param2ui(
-            params.modulation_frequency,
+            self.parameters.modulation_frequency,
             self.ids.modulation_frequency,
             lambda value: value / MHz,
         )
         param2ui(
-            params.modulation_amplitude,
+            self.parameters.modulation_amplitude,
             self.ids.modulation_amplitude,
             lambda value: value / Vpp,
         )
-        param2ui(params.ramp_speed, self.ids.ramp_speed)
+        param2ui(self.parameters.ramp_speed, self.ids.ramp_speed)
 
-        params.dual_channel.on_change(self.dual_channel_changed)
+        self.parameters.dual_channel.on_change(self.dual_channel_changed)
 
     def change_modulation_frequency(self):
         self.parameters.modulation_frequency.value = (

--- a/linien/gui/ui/modulation_ramp_panel.py
+++ b/linien/gui/ui/modulation_ramp_panel.py
@@ -24,8 +24,8 @@ class ModulationAndRampPanel(QtGui.QWidget, CustomWidget):
         self.ids.spectroscopyTabs.setCurrentIndex(0)
 
     def connection_established(self):
-        params = self.app().parameters
-        self.control = self.app().control
+        params = self.app.parameters
+        self.control = self.app.control
         self.parameters = params
 
         param2ui(

--- a/linien/gui/ui/optimization_panel.py
+++ b/linien/gui/ui/optimization_panel.py
@@ -48,9 +48,9 @@ class OptimizationPanel(QtGui.QWidget, CustomWidget):
             getattr(self.ids, param_name).stateChanged.connect(optim_enabled_changed)
 
     def connection_established(self):
-        params = self.app().parameters
+        params = self.app.parameters
         self.parameters = params
-        self.control = self.app().control
+        self.control = self.app.control
 
         def opt_running_changed(_):
             running = params.optimization_running.value

--- a/linien/gui/ui/optimization_panel.py
+++ b/linien/gui/ui/optimization_panel.py
@@ -48,14 +48,13 @@ class OptimizationPanel(QtGui.QWidget, CustomWidget):
             getattr(self.ids, param_name).stateChanged.connect(optim_enabled_changed)
 
     def connection_established(self):
-        params = self.app.parameters
-        self.parameters = params
+        self.parameters = self.app.parameters
         self.control = self.app.control
 
         def opt_running_changed(_):
-            running = params.optimization_running.value
-            approaching = params.optimization_approaching.value
-            failed = params.optimization_failed.value
+            running = self.parameters.optimization_running.value
+            approaching = self.parameters.optimization_approaching.value
+            failed = self.parameters.optimization_failed.value
 
             self.ids.optimization_not_running_container.setVisible(
                 not failed and not running
@@ -68,20 +67,20 @@ class OptimizationPanel(QtGui.QWidget, CustomWidget):
             )
             self.ids.optimization_failed.setVisible(failed)
 
-        params.optimization_running.on_change(opt_running_changed)
-        params.optimization_approaching.on_change(opt_running_changed)
-        params.optimization_failed.on_change(opt_running_changed)
+        self.parameters.optimization_running.on_change(opt_running_changed)
+        self.parameters.optimization_approaching.on_change(opt_running_changed)
+        self.parameters.optimization_failed.on_change(opt_running_changed)
 
         def opt_selection_changed(value):
             self.ids.optimization_selecting.setVisible(value)
             self.ids.optimization_not_selecting.setVisible(not value)
 
-        params.optimization_selection.on_change(opt_selection_changed)
+        self.parameters.optimization_selection.on_change(opt_selection_changed)
 
         def mod_param_changed(_):
-            dual_channel = params.dual_channel.value
-            channel = params.optimization_channel.value
-            optimized = params.optimization_optimized_parameters.value
+            dual_channel = self.parameters.dual_channel.value
+            channel = self.parameters.optimization_channel.value
+            optimized = self.parameters.optimization_optimized_parameters.value
 
             self.ids.optimization_display_parameters.setText(
                 """<br />
@@ -90,11 +89,12 @@ class OptimizationPanel(QtGui.QWidget, CustomWidget):
                 <br />
                 """
                 % (
-                    params.modulation_frequency.value / MHz,
-                    params.modulation_amplitude.value / Vpp,
-                    (params.demodulation_phase_a, params.demodulation_phase_b)[
-                        0 if not dual_channel else (0, 1)[channel]
-                    ].value,
+                    self.parameters.modulation_frequency.value / MHz,
+                    self.parameters.modulation_amplitude.value / Vpp,
+                    (
+                        self.parameters.demodulation_phase_a,
+                        self.parameters.demodulation_phase_b,
+                    )[0 if not dual_channel else (0, 1)[channel]].value,
                     optimized[0] / MHz,
                     optimized[1] / Vpp,
                     optimized[2],
@@ -102,28 +102,43 @@ class OptimizationPanel(QtGui.QWidget, CustomWidget):
             )
 
         for p in (
-            params.modulation_amplitude,
-            params.modulation_frequency,
-            params.demodulation_phase_a,
+            self.parameters.modulation_amplitude,
+            self.parameters.modulation_frequency,
+            self.parameters.demodulation_phase_a,
         ):
             p.on_change(mod_param_changed)
 
         def improvement_changed(improvement):
             self.ids.optimization_improvement.setText("%d %%" % (improvement * 100))
 
-        params.optimization_improvement.on_change(improvement_changed)
+        self.parameters.optimization_improvement.on_change(improvement_changed)
 
-        param2ui(params.optimization_mod_freq_enabled, self.ids.optimization_mod_freq)
-        param2ui(params.optimization_mod_freq_min, self.ids.optimization_mod_freq_min)
-        param2ui(params.optimization_mod_freq_max, self.ids.optimization_mod_freq_max)
-        param2ui(params.optimization_mod_amp_enabled, self.ids.optimization_mod_amp)
-        param2ui(params.optimization_mod_amp_min, self.ids.optimization_mod_amp_min)
-        param2ui(params.optimization_mod_amp_max, self.ids.optimization_mod_amp_max)
+        param2ui(
+            self.parameters.optimization_mod_freq_enabled,
+            self.ids.optimization_mod_freq,
+        )
+        param2ui(
+            self.parameters.optimization_mod_freq_min,
+            self.ids.optimization_mod_freq_min,
+        )
+        param2ui(
+            self.parameters.optimization_mod_freq_max,
+            self.ids.optimization_mod_freq_max,
+        )
+        param2ui(
+            self.parameters.optimization_mod_amp_enabled, self.ids.optimization_mod_amp
+        )
+        param2ui(
+            self.parameters.optimization_mod_amp_min, self.ids.optimization_mod_amp_min
+        )
+        param2ui(
+            self.parameters.optimization_mod_amp_max, self.ids.optimization_mod_amp_max
+        )
 
         def dual_channel_changed(value):
             self.ids.optimization_channel_selector_box.setVisible(value)
 
-        params.dual_channel.on_change(dual_channel_changed)
+        self.parameters.dual_channel.on_change(dual_channel_changed)
 
     def start_optimization(self):
         self.parameters.optimization_selection.value = True

--- a/linien/gui/ui/plot_widget.py
+++ b/linien/gui/ui/plot_widget.py
@@ -206,8 +206,8 @@ class PlotWidget(pg.PlotWidget, CustomWidget):
         return x, y
 
     def connection_established(self):
-        self.control = self.app().control
-        self.parameters = self.app().parameters
+        self.control = self.app.control
+        self.parameters = self.app.parameters
 
         def set_pens(color):
             pen_width = self.parameters.plot_line_width.value

--- a/linien/gui/ui/plot_widget.py
+++ b/linien/gui/ui/plot_widget.py
@@ -206,8 +206,8 @@ class PlotWidget(pg.PlotWidget, CustomWidget):
         return x, y
 
     def connection_established(self):
-        self.control = self.app.control
         self.parameters = self.app.parameters
+        self.control = self.app.control
 
         def set_pens(color):
             pen_width = self.parameters.plot_line_width.value

--- a/linien/gui/ui/psd_plot_widget.py
+++ b/linien/gui/ui/psd_plot_widget.py
@@ -92,8 +92,8 @@ class PSDPlotWidget(pg.PlotWidget, CustomWidget):
         self.recalculate_min_max()
 
     def connection_established(self):
-        self.control = self.app.control
         self.parameters = self.app.parameters
+        self.control = self.app.control
 
     def plot_curve(self, uuid, psds, color):
         self.curves[uuid] = self.curves.get(uuid, [])

--- a/linien/gui/ui/psd_plot_widget.py
+++ b/linien/gui/ui/psd_plot_widget.py
@@ -92,8 +92,8 @@ class PSDPlotWidget(pg.PlotWidget, CustomWidget):
         self.recalculate_min_max()
 
     def connection_established(self):
-        self.control = self.app().control
-        self.parameters = self.app().parameters
+        self.control = self.app.control
+        self.parameters = self.app.parameters
 
     def plot_curve(self, uuid, psds, color):
         self.curves[uuid] = self.curves.get(uuid, [])

--- a/linien/gui/ui/psd_table_widget.py
+++ b/linien/gui/ui/psd_table_widget.py
@@ -20,8 +20,8 @@ class PSDTableWidget(QtGui.QTableWidget, CustomWidget):
         self.uuids = []
 
     def connection_established(self):
-        self.control = self.app.control
         self.parameters = self.app.parameters
+        self.control = self.app.control
 
     def add_curve(self, uuid, data, color):
         if uuid not in self.uuids:

--- a/linien/gui/ui/psd_table_widget.py
+++ b/linien/gui/ui/psd_table_widget.py
@@ -20,8 +20,8 @@ class PSDTableWidget(QtGui.QTableWidget, CustomWidget):
         self.uuids = []
 
     def connection_established(self):
-        self.control = self.app().control
-        self.parameters = self.app().parameters
+        self.control = self.app.control
+        self.parameters = self.app.parameters
 
     def add_curve(self, uuid, data, color):
         if uuid not in self.uuids:

--- a/linien/gui/ui/psd_window.py
+++ b/linien/gui/ui/psd_window.py
@@ -47,9 +47,8 @@ class PSDWindow(QtGui.QMainWindow, CustomWidget):
         self.parameters.psd_acquisition_max_decimation.value = 12 + index
 
     def connection_established(self):
-        self.control = self.app.control
-        params = self.app.parameters
-        self.parameters = params
+        self.control = self.app.client.control
+        self.parameters = self.app.client.parameters
 
         self.parameters.psd_data_partial.on_change(
             self.psd_data_received,

--- a/linien/gui/ui/psd_window.py
+++ b/linien/gui/ui/psd_window.py
@@ -47,8 +47,8 @@ class PSDWindow(QtGui.QMainWindow, CustomWidget):
         self.parameters.psd_acquisition_max_decimation.value = 12 + index
 
     def connection_established(self):
-        self.control = self.app.client.control
-        self.parameters = self.app.client.parameters
+        self.parameters = self.app.parameters
+        self.control = self.app.control
 
         self.parameters.psd_data_partial.on_change(
             self.psd_data_received,

--- a/linien/gui/ui/ramp_control.py
+++ b/linien/gui/ui/ramp_control.py
@@ -1,7 +1,8 @@
+from linien.gui.widgets import CustomWidget
 import superqt
 
 
-class RampSlider(superqt.QDoubleRangeSlider):
+class RampSlider(superqt.QDoubleRangeSlider, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/linien/gui/ui/ramp_control.py
+++ b/linien/gui/ui/ramp_control.py
@@ -1,14 +1,14 @@
-from linien.gui.widgets import CustomWidget
 import superqt
+from linien.gui.widgets import CustomWidget
 
 
 class RampSlider(superqt.QDoubleRangeSlider, CustomWidget):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def initValues(self):
+    def init(self):
+
+        # set control boundaries
         self.setMinimum(-1.0)
         self.setMaximum(1.0)
         self.setSingleStep(0.001)
-
-        self.setValue((-1.0, 1.0))

--- a/linien/gui/ui/right_panel.py
+++ b/linien/gui/ui/right_panel.py
@@ -7,8 +7,8 @@ class RightPanel(QtGui.QWidget, CustomWidget):
         super().__init__(*args, **kwargs)
 
     def connection_established(self):
-        self.control = self.app().control
-        self.parameters = self.app().parameters
+        self.control = self.app.control
+        self.parameters = self.app.parameters
 
         self.parameters.autolock_running.on_change(self.autolock_status_changed)
         self.parameters.optimization_running.on_change(self.optimization_status_changed)
@@ -28,16 +28,16 @@ class RightPanel(QtGui.QWidget, CustomWidget):
         self.ids.pid_parameter_optimization_button.clicked.connect(self.open_psd_window)
 
     def close_app(self):
-        self.app().close()
+        self.app.close()
 
     def shutdown_server(self):
-        self.app().shutdown()
+        self.app.shutdown()
 
     def open_psd_window(self):
-        self.app().open_psd_window()
+        self.app.open_psd_window()
 
     def open_device_manager(self):
-        self.app().open_device_manager()
+        self.app.open_device_manager()
 
     def autolock_status_changed(self, value):
         if value:

--- a/linien/gui/ui/right_panel.py
+++ b/linien/gui/ui/right_panel.py
@@ -7,8 +7,8 @@ class RightPanel(QtGui.QWidget, CustomWidget):
         super().__init__(*args, **kwargs)
 
     def connection_established(self):
-        self.control = self.app.control
         self.parameters = self.app.parameters
+        self.control = self.app.control
 
         self.parameters.autolock_running.on_change(self.autolock_status_changed)
         self.parameters.optimization_running.on_change(self.optimization_status_changed)

--- a/linien/gui/ui/spectroscopy_panel.py
+++ b/linien/gui/ui/spectroscopy_panel.py
@@ -81,8 +81,8 @@ class SpectroscopyPanel(QtWidgets.QWidget, CustomWidget):
         self.ids.invert.stateChanged.connect(invert_changed)
 
     def connection_established(self):
-        params = self.app().parameters
-        self.control = self.app().control
+        params = self.app.parameters
+        self.control = self.app.control
         self.parameters = params
 
         # self.close_button.clicked.connect(self.close_app)

--- a/linien/gui/ui/spectroscopy_panel.py
+++ b/linien/gui/ui/spectroscopy_panel.py
@@ -81,9 +81,8 @@ class SpectroscopyPanel(QtWidgets.QWidget, CustomWidget):
         self.ids.invert.stateChanged.connect(invert_changed)
 
     def connection_established(self):
-        params = self.app.parameters
+        self.parameters = self.app.parameters
         self.control = self.app.control
-        self.parameters = params
 
         # self.close_button.clicked.connect(self.close_app)
         # self.shutdown_button.clicked.connect(self.shutdown_server)

--- a/linien/gui/ui/view_panel.py
+++ b/linien/gui/ui/view_panel.py
@@ -41,13 +41,12 @@ class ViewPanel(QtGui.QWidget, CustomWidget):
         param.value = (r, g, b, a)
 
     def connection_established(self):
-        params = self.app.parameters
+        self.parameters = self.app.parameters
         self.control = self.app.control
-        self.parameters = params
 
-        param2ui(params.plot_line_width, self.ids.plot_line_width)
-        param2ui(params.plot_line_opacity, self.ids.plot_line_opacity)
-        param2ui(params.plot_fill_opacity, self.ids.plot_fill_opacity)
+        param2ui(self.parameters.plot_line_width, self.ids.plot_line_width)
+        param2ui(self.parameters.plot_line_opacity, self.ids.plot_line_opacity)
+        param2ui(self.parameters.plot_fill_opacity, self.ids.plot_fill_opacity)
 
         def preview_colors(*args):
             for color_idx in range(N_COLORS):

--- a/linien/gui/ui/view_panel.py
+++ b/linien/gui/ui/view_panel.py
@@ -41,8 +41,8 @@ class ViewPanel(QtGui.QWidget, CustomWidget):
         param.value = (r, g, b, a)
 
     def connection_established(self):
-        params = self.app().parameters
-        self.control = self.app().control
+        params = self.app.parameters
+        self.control = self.app.control
         self.parameters = params
 
         param2ui(params.plot_line_width, self.ids.plot_line_width)

--- a/linien/gui/widgets.py
+++ b/linien/gui/widgets.py
@@ -2,7 +2,7 @@ import os
 import weakref
 from os import path
 from PyQt5 import uic
-from pyqtgraph.Qt import QtCore, QtGui
+from pyqtgraph.Qt import QtCore
 
 
 # add ui folder to path

--- a/linien/gui/widgets.py
+++ b/linien/gui/widgets.py
@@ -39,10 +39,15 @@ class CustomWidget:
         """Queries a widget by name."""
         return self.findChild(QtCore.QObject, name)
 
+    @property
     def app(self):
         # this property is set manually. Probably there is a more elegant way
         # to solve this...
-        return self.window().app
+        return self.window()._app
+
+    @app.setter
+    def app(self, app):
+        self._app = app
 
     def load_ui(self, name):
         assert name.endswith(".ui")

--- a/linien/gui/widgets.py
+++ b/linien/gui/widgets.py
@@ -33,6 +33,8 @@ class CustomWidget:
         pass
 
     def connection_established(self):
+        # This is executed the client succesfully established a connection to the server
+        # and can be extended by inheritting classes.
         pass
 
     def get_widget(self, name):


### PR DESCRIPTION
At the moment mostly renaming `connection` to `client` and working explicitly on `self.parameters` rather than the local variable `params`. I personally think the latter is clearer but it might be considered visual clutter (it rarely adds extra lines, though). @hermitdemschoenenleben, please decide what you prefer.

I also turned the `app` member in `widgets.py` into a property so that in all widgets, `self.app` can be used, rather than `self.app()` in some cases.