### PR TITLE
Use Git LFS for storing the FPGA images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bin filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /build/*
 !/build/.keep_me
 __pycache__
-*.bin
 *.vcd
 *.sav
 *.pdf

--- a/linien/server/linien.bin
+++ b/linien/server/linien.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4427f9931b6b476301dd9eb26c722fd1a69ebfbb5377495e2216ee4222688d93
+size 2083740


### PR DESCRIPTION
Setting up Large File Storage (LFS) for git is actually super easy and free storage is up to 1 GB (more than enough for us).

https://git-lfs.github.com/

@hermitdemschoenenleben: What do you think? 

This will merge into the fast-mode branch (I build the fpga image for this branch).