### PR TITLE
Fix FPGA script paths.

### DIFF
--- a/scripts/build_fpga_image.sh
+++ b/scripts/build_fpga_image.sh
@@ -5,10 +5,10 @@ SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 cd $SCRIPTPATH/../
 
-VIVADOPATH=/tools/Xilinx/Vivado/2020.1/bin
+VIVADOPATH=~/Xilinx/Vivado/2020.2/bin
 if [ ! -d $VIVADOPATH ]
 then
-echo "vivado path $VIVADOPATH does not exist. Please adapt it in build_gateware.sh"
+echo "vivado path $VIVADOPATH does not exist. Please adapt it in build_fpga_image.sh"
 exit 1
 fi
 

--- a/scripts/build_fpga_image.sh
+++ b/scripts/build_fpga_image.sh
@@ -5,7 +5,7 @@ SCRIPT=`realpath $0`
 SCRIPTPATH=`dirname $SCRIPT`
 cd $SCRIPTPATH/../
 
-VIVADOPATH=~/Xilinx/Vivado/2020.2/bin
+VIVADOPATH=~/xilinx/Vivado/2020.2/bin
 if [ ! -d $VIVADOPATH ]
 then
 echo "vivado path $VIVADOPATH does not exist. Please adapt it in build_fpga_image.sh"

--- a/scripts/fpga_image_helper.py
+++ b/scripts/fpga_image_helper.py
@@ -3,10 +3,11 @@
 
 # this file compiles the FPGA image. You shouldn't call it directly though but
 # use `build_fpga_image.sh`
-
-LINIEN_FOLDER = "/".join(__file__.split("/")[:-2])
 import os
 import sys
+
+LINIEN_FOLDER = "/".join(os.path.abspath(__file__).split("/")[:-2])
+
 
 os.chdir(LINIEN_FOLDER)
 sys.path.append(LINIEN_FOLDER)


### PR DESCRIPTION
Fixed the paths for `build_fpga_image.sh` and the python helper file. It now works out of the box for the build server that @hermitdemschoenenleben  and me are using. 

See also #220  for storing the FPGA images on github.