### PR TITLE
Improve tests

### DIFF
--- a/gateware/logic/delta_sigma.py
+++ b/gateware/logic/delta_sigma.py
@@ -81,4 +81,3 @@ if __name__ == "__main__":
         # plt.plot(y.ravel())
         plt.psd(np.array(y), detrend=plt.mlab.detrend_mean, NFFT=4096 * 2)
         plt.xscale("log")
-    plt.show()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers = slow : marks tests as slow (deselect with '-m "not slow"')
+
+plt_dirname = tests/plots

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
-markers = slow : marks tests as slow (deselect with '-m "not slow"')
-
 plt_dirname = tests/plots
+
+# don't complain about plt_dirname
+filterwarnings = ignore::pytest.PytestConfigWarning 
+
+markers = slow : marks tests as slow (deselect with '-m "not slow"')

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,3 +9,4 @@ matplotlib
 migen
 pytest
 git+https://github.com/m-labs/misoc
+pytest-plt

--- a/tests/test_algorithm_selection.py
+++ b/tests/test_algorithm_selection.py
@@ -41,7 +41,10 @@ class FakeControl:
 
     def exposed_write_data(self):
         print(
-            f"write: center={self.parameters.center.value} amp={self.parameters.ramp_amplitude.value}"
+            f"""
+            write: center={self.parameters.center.value}\n
+            amp={self.parameters.ramp_amplitude.value}
+            """
         )
 
     def exposed_start_lock(self):

--- a/tests/test_approacher.py
+++ b/tests/test_approacher.py
@@ -42,7 +42,7 @@ class FakeControl:
         )
 
 
-def test_approacher():
+def test_approacher(plt):
     def _get_signal(shift):
         return get_signal(
             parameters.ramp_amplitude.value, parameters.center.value, shift
@@ -69,9 +69,8 @@ def test_approacher():
                 peak_idxs,
             ) = get_lock_point(reference_signal, 0, len(reference_signal))
 
-            """plt.plot(reference_signal)
+            plt.plot(reference_signal)
             plt.plot(rolled_reference_signal)
-            plt.show()"""
 
             assert abs(central_y - Y_SHIFT) < 1
 

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -1,6 +1,10 @@
+from pathlib import Path
+
 from migen import run_simulation
 
 from gateware.logic.limit import Limit
+
+VCD_DIR = Path(__file__).parent / "vcd"
 
 
 def test_limit():
@@ -36,4 +40,4 @@ def test_limit():
 
     dut = Limit(16)
     n = 1 << 6
-    run_simulation(dut, tb(dut, n), vcd_name="limit.vcd")
+    run_simulation(dut, tb(dut, n), vcd_name=VCD_DIR / "limit.vcd")

--- a/tests/test_modulate.py
+++ b/tests/test_modulate.py
@@ -1,5 +1,5 @@
-import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 from migen import Module, Signal, run_simulation
 
 from gateware.logic.modulate import Demodulate, Modulate
@@ -25,7 +25,8 @@ def block_average(a, n):
 factor = 5
 
 
-def test_modulate():
+@pytest.mark.slow
+def test_modulate(plt):
     width = 16
     data = []
     phase = []
@@ -84,7 +85,6 @@ def test_modulate():
     plt.plot(np.sqrt(averaged1 ** 2 + averaged2 ** 2), label="averaged+averaged")
 
     plt.legend()
-    plt.show()
 
 
 if __name__ == "__main__":

--- a/tests/test_modulate.py
+++ b/tests/test_modulate.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 from migen import Module, Signal, run_simulation
 
 from gateware.logic.modulate import Demodulate, Modulate
+
+VCD_DIR = Path(__file__).parent / "vcd"
 
 
 def moving_average(a, n):
@@ -71,7 +75,7 @@ def test_modulate(plt):
             ]
 
     dut = Combined()
-    run_simulation(dut, tb(dut), vcd_name="modulate.vcd")
+    run_simulation(dut, tb(dut), vcd_name=VCD_DIR / "modulate.vcd")
 
     """        """
     plt.plot(data, label="y")

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -4,7 +4,7 @@ from migen import run_simulation
 from gateware.logic.pid import PID
 
 
-def test_pid():
+def test_pid(plt):
     def pid_testbench(pid):
         def test_not_running():
             input_ = 1000
@@ -28,7 +28,7 @@ def test_pid():
             yield pid.ki.storage.eq(0)
             yield pid.kd.storage.eq(0)
 
-            for i in range(10):
+            for _ in range(10):
                 yield
 
             out = yield pid.pid_out
@@ -108,11 +108,10 @@ def test_pid():
                     out = yield pid.pid_out
                     y.append(out)
 
-                # plt.plot(x)
-                # plt.plot(y)
+                plt.plot(x)
+                plt.plot(y)
 
                 ys.append(y)
-            # plt.show()
 
             assert np.all(np.abs(np.array(ys[0][10:]) - np.array(ys[1][10:])) <= 1)
 

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,5 +1,4 @@
 import numpy as np
-from matplotlib import pyplot as plt
 from migen import run_simulation
 
 from gateware.logic.pid import PID

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import numpy as np
 from migen import run_simulation
 
 from gateware.logic.pid import PID
+
+VCD_DIR = Path(__file__).parent / "vcd"
 
 
 def test_pid(plt):
@@ -122,7 +126,7 @@ def test_pid(plt):
         yield from test_d()
 
     pid = PID(width=25)
-    run_simulation(pid, pid_testbench(pid), vcd_name="pid.vcd")
+    run_simulation(pid, pid_testbench(pid), vcd_name=VCD_DIR / "pid.vcd")
 
 
 if __name__ == "__main__":

--- a/tests/test_pid_transfer.py
+++ b/tests/test_pid_transfer.py
@@ -1,11 +1,12 @@
 import numpy as np
-from matplotlib import pyplot as plt
+import pytest
 from migen import run_simulation
 
 from gateware.logic.pid import PID
 
 
-def test_pid_transfer():
+@pytest.mark.slow
+def test_pid_transfer(plt):
     def pid_testbench(pid):
         np.random.seed(299792458)
         amplitude = 0.01
@@ -91,7 +92,6 @@ def test_pid_transfer():
         plt.legend(loc=(1.04, 0))
         plt.grid()
         plt.tight_layout()
-        plt.show()
 
     pid = PID(width=25)
     run_simulation(pid, pid_testbench(pid), vcd_name="pid.vcd")

--- a/tests/test_pid_transfer.py
+++ b/tests/test_pid_transfer.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 from migen import run_simulation
 
 from gateware.logic.pid import PID
+
+VCD_DIR = Path(__file__).parent / "vcd"
 
 
 @pytest.mark.slow
@@ -94,7 +98,7 @@ def test_pid_transfer(plt):
         plt.tight_layout()
 
     pid = PID(width=25)
-    run_simulation(pid, pid_testbench(pid), vcd_name="pid.vcd")
+    run_simulation(pid, pid_testbench(pid), vcd_name=VCD_DIR / "pid.vcd")
 
 
 if __name__ == "__main__":

--- a/tests/test_robust_autolock.py
+++ b/tests/test_robust_autolock.py
@@ -1,5 +1,5 @@
 import numpy as np
-from matplotlib import pyplot as plt
+import pytest
 from migen import run_simulation
 
 from gateware.logic.autolock import (
@@ -64,7 +64,8 @@ def add_jitter(spectrum, level=None, exact_value=None):
     return np.roll(spectrum, shift)
 
 
-def test_get_description(debug=False):
+@pytest.mark.slow
+def test_get_description(plt, debug=True):
     for sign_spectrum_multiplicator in (1, -1):
         for spectrum_generator in (pfd_spectrum, atomic_spectrum):
             spectrum, target_idxs = spectrum_generator(0)
@@ -72,7 +73,6 @@ def test_get_description(debug=False):
 
             if debug:
                 plt.plot(spectrum)
-                plt.show()
 
             jitters = [
                 0 if i == 0 else int(round(np.random.randn() * 50)) for i in range(10)
@@ -148,7 +148,6 @@ def test_get_description(debug=False):
                 )
 
                 plt.legend()
-                plt.show()
 
 
 def test_dynamic_delay():
@@ -246,7 +245,8 @@ def test_sum_diff_calculator2():
     assert out_fpga[1:] == summed_xscaled[:-1]
 
 
-def test_compare_sum_diff_calculator_implementations(debug=False):
+@pytest.mark.slow
+def test_compare_sum_diff_calculator_implementations(plt, debug=True):
     for iteration in (0, 1):
         if iteration == 1:
             spectrum, target_idxs = atomic_spectrum(0)
@@ -292,7 +292,6 @@ def test_compare_sum_diff_calculator_implementations(debug=False):
                 label="FPGA calculation",
             )
             plt.legend()
-            plt.show()
 
             plt.plot(
                 summed_xscaled[:-FPGA_DELAY_SUMDIFF_CALCULATOR],
@@ -303,7 +302,6 @@ def test_compare_sum_diff_calculator_implementations(debug=False):
                 label="FPGA calculation",
             )
             plt.legend()
-            plt.show()
 
         assert (
             summed[:-FPGA_DELAY_SUMDIFF_CALCULATOR]
@@ -404,7 +402,7 @@ def test_fpga_lock_position_finder():
     )
 
 
-def test_crop_spectra_to_same_view():
+def test_crop_spectra_to_same_view(plt):
     spectra_to_test = (
         [np.roll(atomic_spectrum(0)[0], -i * 10) for i in range(10)],
         [np.roll(atomic_spectrum(0)[0], i * 10) for i in range(10)],
@@ -423,8 +421,7 @@ def test_crop_spectra_to_same_view():
         for cropped_spectrum in cropped_spectra:
             assert np.all(cropped_spectrum == cropped_spectra[0])
 
-            # plt.plot(cropped_spectrum)
-        # plt.show()
+            plt.plot(cropped_spectrum)
 
 
 if __name__ == "__main__":
@@ -434,4 +431,4 @@ if __name__ == "__main__":
     test_sum_diff_calculator()
     test_sum_diff_calculator2()
     test_fpga_lock_position_finder()
-    test_get_description(debug=False)
+    test_get_description(debug=True)

--- a/tests/test_robust_autolock.py
+++ b/tests/test_robust_autolock.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 from migen import run_simulation
@@ -19,6 +21,7 @@ from linien.server.autolock.utils import (
     sum_up_spectrum,
 )
 
+VCD_DIR = Path(__file__).parent / "vcd"
 FPGA_DELAY_SUMDIFF_CALCULATOR = 2
 
 
@@ -167,7 +170,9 @@ def test_dynamic_delay():
         assert out == 1
 
     dut = DynamicDelay(14 + 14, max_delay=8191)
-    run_simulation(dut, tb(dut), vcd_name="experimental_autolock_dynamic_delay.vcd")
+    run_simulation(
+        dut, tb(dut), vcd_name=VCD_DIR / "experimental_autolock_dynamic_delay.vcd"
+    )
 
 
 def test_sum_diff_calculator():
@@ -210,7 +215,7 @@ def test_sum_diff_calculator():
 
     dut = SumDiffCalculator(14, 8192)
     run_simulation(
-        dut, tb(dut), vcd_name="experimental_autolock_sum_diff_calculator.vcd"
+        dut, tb(dut), vcd_name=VCD_DIR / "experimental_autolock_sum_diff_calculator.vcd"
     )
 
 
@@ -233,7 +238,7 @@ def test_sum_diff_calculator2():
 
     dut = SumDiffCalculator(14, 8192)
     run_simulation(
-        dut, tb(dut), vcd_name="experimental_autolock_sum_diff_calculator.vcd"
+        dut, tb(dut), vcd_name=VCD_DIR / "experimental_autolock_sum_diff_calculator.vcd"
     )
 
     summed = sum_up_spectrum(spectrum)
@@ -280,7 +285,9 @@ def test_compare_sum_diff_calculator_implementations(plt, debug=True):
 
         dut = RobustAutolock()
         run_simulation(
-            dut, tb(dut), vcd_name="experimental_autolock_fpga_lock_position_finder.vcd"
+            dut,
+            tb(dut),
+            vcd_name=VCD_DIR / "experimental_autolock_fpga_lock_position_finder.vcd",
         )
 
         if debug:
@@ -398,7 +405,9 @@ def test_fpga_lock_position_finder():
 
     dut = RobustAutolock()
     run_simulation(
-        dut, tb(dut), vcd_name="experimental_autolock_fpga_lock_position_finder.vcd"
+        dut,
+        tb(dut),
+        vcd_name=VCD_DIR / "experimental_autolock_fpga_lock_position_finder.vcd",
     )
 
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 from migen import run_simulation
 
 from gateware.linien import LinienLogic
 from gateware.logic.pid import PID
 from gateware.logic.sweep import SweepCSR
+
+VCD_DIR = Path(__file__).parent / "vcd"
 
 
 def test_root():
@@ -90,11 +94,11 @@ def test_root():
                     assert pid_running == 0
 
     dut = LinienLogic()
-    run_simulation(dut, tb(dut, 0), vcd_name="root.vcd")
+    run_simulation(dut, tb(dut, 0), vcd_name=VCD_DIR / "root.vcd")
     dut = LinienLogic()
-    run_simulation(dut, tb(dut, -40), vcd_name="root.vcd")
+    run_simulation(dut, tb(dut, -40), vcd_name=VCD_DIR / "root.vcd")
     dut = LinienLogic()
-    run_simulation(dut, tb(dut, 51), vcd_name="root.vcd")
+    run_simulation(dut, tb(dut, 51), vcd_name=VCD_DIR / "root.vcd")
 
 
 if __name__ == "__main__":

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -94,11 +94,11 @@ def test_root():
                     assert pid_running == 0
 
     dut = LinienLogic()
-    run_simulation(dut, tb(dut, 0), vcd_name=VCD_DIR / "root.vcd")
+    run_simulation(dut, tb(dut, 0), vcd_name=VCD_DIR / "root_target0.vcd")
     dut = LinienLogic()
-    run_simulation(dut, tb(dut, -40), vcd_name=VCD_DIR / "root.vcd")
+    run_simulation(dut, tb(dut, -40), vcd_name=VCD_DIR / "root_target-40.vcd")
     dut = LinienLogic()
-    run_simulation(dut, tb(dut, 51), vcd_name=VCD_DIR / "root.vcd")
+    run_simulation(dut, tb(dut, 51), vcd_name=VCD_DIR / "root_target_51.vcd")
 
 
 if __name__ == "__main__":

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,10 +1,9 @@
-import matplotlib.pyplot as plt
 from migen import run_simulation
 
 from gateware.logic.sweep import SweepCSR
 
 
-def test_sweep():
+def test_sweep(plt):
     # s = Sweep(16)
     # from migen.fhdl import verilog
     # print(verilog.convert(s, ios=set()))
@@ -31,11 +30,9 @@ def test_sweep():
     dut = SweepCSR(width=16)
     run_simulation(dut, tb(dut, out, n), vcd_name="sweep.vcd")
 
-    if False:
-        plt.plot(out, label="ramp output")
-        plt.plot([v * max(out) for v in trig], label="trigger_signal")
-        plt.legend()
-        plt.show()
+    plt.plot(out, label="ramp output")
+    plt.plot([v * max(out) for v in trig], label="trigger_signal")
+    plt.legend()
 
     assert out[66] == -1024
     assert trig[66] == 1

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1,6 +1,10 @@
+from pathlib import Path
+
 from migen import run_simulation
 
 from gateware.logic.sweep import SweepCSR
+
+VCD_DIR = Path(__file__).parent / "vcd"
 
 
 def test_sweep(plt):
@@ -28,10 +32,10 @@ def test_sweep(plt):
     out = []
     trig = []
     dut = SweepCSR(width=16)
-    run_simulation(dut, tb(dut, out, n), vcd_name="sweep.vcd")
+    run_simulation(dut, tb(dut, out, n), vcd_name=VCD_DIR / "sweep.vcd")
 
     plt.plot(out, label="ramp output")
-    plt.plot([v * max(out) for v in trig], label="trigger_signal")
+    plt.plot([v * max(out) for v in trig], label=VCD_DIR / "trigger_signal")
     plt.legend()
 
     assert out[66] == -1024

--- a/tests/vcd/.gitignore
+++ b/tests/vcd/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all other files in this folder since they are only used for storing files for
+# testing.
+*
+!.gitignore


### PR DESCRIPTION
Added `pytest-plt` for plotting and marked some tests as slow. Tests can now be run from the root directory with `pytest`. 

To produce plots, run `pytest --plots`. Some of the tests take a long time. To skip them, run `pytest -m "not slow"` (I simply marked those tests that took longer than 10 seconds on my machine, identified by `pytest --durations=0`.

The VCD files are now stored in `tests/vcd`. Maybe [this](https://pyvcd.readthedocs.io/en/latest/vcd.gtkw.html) can also be incorporated at some points to automatically show the relevant data when opening a vcd with GTKwave.

Note that `test_root.py` still fails, see #224.

I left in the `debug` keyword for now (but I set it to `True` by default). I think there is a cleaner way in pytest to achieve this but I would just change this the next time somebody activly works on specific tests.