### PR TITLE
Add packaging to requirements.

### DIFF
--- a/requirements_gui.txt
+++ b/requirements_gui.txt
@@ -20,3 +20,4 @@ scipy==1.4.1
 six==1.15.0
 uuid==1.30
 superqt==0.2.3
+packaging==21.3


### PR DESCRIPTION
The missing requirement prevented the github action of pyinstaller for Windows from producing a working file.